### PR TITLE
:zap: Add option to use mamba solver, and use it by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ Sample workflow step:
   uses: weiji14/conda-lock-refresh@main
   with:
     file: "environment.yml"
-    kind: "explicit"
+    kind: "lock"
+    mamba: true
     platform: "linux-64"
 ```
 
@@ -33,6 +34,7 @@ https://conda.github.io/conda-lock/cli/gen/#conda-lock-lock
 |:--:|:--|:--|
 | `file` | Path to the conda environment specification(s) | environment.yml |
 | `kind` | Kind of lock file(s) to generate [should be one of 'lock', 'explicit', or 'env'] | lock |
+| `mamba` | Use the mamba solver [should be either 'true' or 'false'] | true |
 | `platform` | The platforms to generate the lockfile for | linux-64 |
 
 

--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ https://conda.github.io/conda-lock/cli/gen/#conda-lock-lock
 
 | Parameter | Description | Default |
 |:--:|:--|:--|
-| `file` | Path to the conda environment specification(s) | environment.yml |
-| `kind` | Kind of lock file(s) to generate [should be one of 'lock', 'explicit', or 'env'] | lock |
-| `mamba` | Use the mamba solver [should be either 'true' or 'false'] | true |
-| `platform` | The platforms to generate the lockfile for | linux-64 |
+| `file` | Path to the conda environment specification(s) | "environment.yml" |
+| `kind` | Kind of lock file(s) to generate [should be one of 'lock', 'explicit', or 'env'] | "lock" |
+| `mamba` | Use the mamba solver [should be either true or false] | true |
+| `platform` | The platforms to generate the lockfile for | "linux-64" |
 
 
 ## References

--- a/action.yml
+++ b/action.yml
@@ -52,7 +52,7 @@ runs:
         rm --force conda-lock.yml
         conda-lock lock $MAMBA --file ${{ inputs.file }} --kind ${{ inputs.kind }} --platform ${{ inputs.platform }}
       env:
-        MAMBA: ${{ fromJSON('{"false": "--no-mamba", "true": "--mamba"}')[inputs.mamba] }}
+        MAMBA: "${{ fromJSON('{"false": "--no-mamba", "true": "--mamba"}')[inputs.mamba] }}"
       shell: bash -l {0}
 
     # Print contents of lockfile

--- a/action.yml
+++ b/action.yml
@@ -25,15 +25,13 @@ inputs:
 runs:
   using: "composite"
   steps:
-    # Setup Python environment
-    - uses: actions/setup-python@v4
+    # Install conda-lock library with Micromamba
+    - uses: mamba-org/setup-micromamba@v1
       with:
-        python-version: '3.11'
-
-    # Install conda-lock library and show version
-    - name: Install conda-lock
-      run: python -m pip install conda-lock
-      shell: bash -l {0}
+        environment-name: conda-lock-env
+        create-args: >-
+          python=3.11
+          conda-lock
 
     # Print debugging information
     - name: Print debug info

--- a/action.yml
+++ b/action.yml
@@ -52,7 +52,7 @@ runs:
         rm --force conda-lock.yml
         conda-lock lock $MAMBA --file ${{ inputs.file }} --kind ${{ inputs.kind }} --platform ${{ inputs.platform }}
       env:
-        MAMBA: fromJSON('{"false": "--no-mamba", "true": "--mamba"}')[inputs.mamba]
+        MAMBA: ${{ fromJSON('{"false": "--no-mamba", "true": "--mamba"}')[inputs.mamba] }}
       shell: bash -l {0}
 
     # Print contents of lockfile

--- a/action.yml
+++ b/action.yml
@@ -39,6 +39,7 @@ runs:
     - name: Print debug info
       run: |
         conda-lock --version
+        mamba --version
         echo Locking ${{ inputs.file }} file for ${{ inputs.platform }} platform.
       shell: bash -l {0}
 

--- a/action.yml
+++ b/action.yml
@@ -52,7 +52,7 @@ runs:
         rm --force conda-lock.yml
         conda-lock lock $MAMBA --file ${{ inputs.file }} --kind ${{ inputs.kind }} --platform ${{ inputs.platform }}
       env:
-        MAMBA: "${{ fromJSON('{false: "--no-mamba", true: "--mamba"}')[inputs.mamba] }}"
+        MAMBA: "${{ inputs.mamba && '--mamba' || '--no-mamba' }}"  # use --mamba if true, else --no-mamba
       shell: bash -l {0}
 
     # Print contents of lockfile

--- a/action.yml
+++ b/action.yml
@@ -52,7 +52,7 @@ runs:
         rm --force conda-lock.yml
         conda-lock lock $MAMBA --file ${{ inputs.file }} --kind ${{ inputs.kind }} --platform ${{ inputs.platform }}
       env:
-        MAMBA: "${{ fromJSON('{"false": "--no-mamba", "true": "--mamba"}')[inputs.mamba] }}"
+        MAMBA: "${{ fromJSON('{false: "--no-mamba", true: "--mamba"}')[inputs.mamba] }}"
       shell: bash -l {0}
 
     # Print contents of lockfile

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: "Kind of lock file(s) to generate [should be one of 'lock', 'explicit', or 'env']"
     required: false
     default: 'lock'
+  mamba:
+    description: "Use the mamba solver [should be either 'true' or 'false']"
+    required: false
+    default: true
   platform:
     description: 'The platforms to generate the lockfile for'
     required: false
@@ -46,7 +50,9 @@ runs:
     - name: Run conda-lock
       run: |
         rm --force conda-lock.yml
-        conda-lock lock --mamba --file ${{ inputs.file }} --kind ${{ inputs.kind }} --platform ${{ inputs.platform }}
+        conda-lock lock $MAMBA --file ${{ inputs.file }} --kind ${{ inputs.kind }} --platform ${{ inputs.platform }}
+      env:
+        MAMBA: fromJSON('{"false": "--no-mamba", "true": "--mamba"}')[inputs.mamba]
       shell: bash -l {0}
 
     # Print contents of lockfile

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,7 @@ runs:
         create-args: >-
           python=3.11
           conda-lock
+          mamba
 
     # Print debugging information
     - name: Print debug info
@@ -45,7 +46,7 @@ runs:
     - name: Run conda-lock
       run: |
         rm --force conda-lock.yml
-        conda-lock lock --file ${{ inputs.file }} --kind ${{ inputs.kind }} --platform ${{ inputs.platform }}
+        conda-lock lock --mamba --file ${{ inputs.file }} --kind ${{ inputs.kind }} --platform ${{ inputs.platform }}
       shell: bash -l {0}
 
     # Print contents of lockfile

--- a/conda-lock.yml
+++ b/conda-lock.yml
@@ -55,26 +55,15 @@ package:
     sha256: f6cc89d887555912d6c61b295d398cff9ec982a3417d38025c45d5dd9b9e79cd
   category: main
   optional: false
-- name: libgfortran5
-  version: 13.1.0
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-13.1.0-h15d22d2_0.conda
-  hash:
-    md5: afb656a334c409dd9805508af1c89c7a
-    sha256: a06235f4c4b85b463d9b8a73c9e10c1b5b4105f8a0ea8ac1f2f5f64edac3dfe7
-  category: main
-  optional: false
 - name: libstdcxx-ng
-  version: 13.1.0
+  version: 13.2.0
   manager: conda
   platform: linux-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-13.1.0-hfd8a6a1_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-13.2.0-h7e041cc_2.conda
   hash:
-    md5: 067bcc23164642f4c226da631f2a2e1d
-    sha256: 6f9eb2d7a96687938c0001166a3b308460a8eb02b10e9d0dd9e251f0219ea05c
+    md5: 9172c297304f2a20134fc56c97fbe229
+    sha256: ab22ecdc974cdbe148874ea876d9c564294d5eafa760f403ed4fd495307b4243
   category: main
   optional: false
 - name: python_abi
@@ -82,10 +71,10 @@ package:
   manager: conda
   platform: linux-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.11-3_cp311.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.11-4_cp311.conda
   hash:
-    md5: c2e2630ddb68cf52eec74dc7dfab20b5
-    sha256: 2966a87dcb0b11fad28f9fe8216bfa4071115776b47ffc7547492fed176e1a1f
+    md5: d786502c97404c94d7d58d258a445a65
+    sha256: 0be3ac1bf852d64f553220c7e6457e9c047dfb7412da9d22fbaa67e60858b3cf
   category: main
   optional: false
 - name: tzdata
@@ -99,28 +88,16 @@ package:
     sha256: 0449138224adfa125b220154408419ec37c06b0b49f63c5954724325903ecf55
   category: main
   optional: false
-- name: libgfortran-ng
-  version: 13.1.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgfortran5: 13.1.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-13.1.0-h69a702a_0.conda
-  hash:
-    md5: 506dc07710dd5b0ba63cbf134897fc10
-    sha256: 429e1d8a3e70b632df5b876e3fc322a56f769756693daa07114c46fa5098684e
-  category: main
-  optional: false
 - name: libgomp
-  version: 13.1.0
+  version: 13.2.0
   manager: conda
   platform: linux-64
   dependencies:
     _libgcc_mutex: '0.1'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-13.1.0-he5830b7_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-13.2.0-h807b86a_2.conda
   hash:
-    md5: 56ca14d57ac29a75d23a39eb3ee0ddeb
-    sha256: 5d441d80b57f857ad305a65169a6b915d4fd6735cdc9e9bded35d493c91ef16d
+    md5: e2042154faafe61969556f28bade94b9
+    sha256: e1e82348f8296abfe344162b3b5f0ddc2f504759ebeb8b337ba99beaae583b15
   category: main
   optional: false
 - name: _openmp_mutex
@@ -137,16 +114,16 @@ package:
   category: main
   optional: false
 - name: libgcc-ng
-  version: 13.1.0
+  version: 13.2.0
   manager: conda
   platform: linux-64
   dependencies:
     _libgcc_mutex: '0.1'
     _openmp_mutex: '>=4.5'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.1.0-he5830b7_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.2.0-h807b86a_2.conda
   hash:
-    md5: cd93f779ff018dd85c7544c015c9db3c
-    sha256: fba897a02f35b2b5e6edc43a746d1fa6970a77b422f258246316110af8966911
+    md5: c28003b0be0494f9a7664389146716ff
+    sha256: d361d3c87c376642b99c1fc25cddec4b9905d3d9b9203c1c545b8c8c1b04539a
   category: main
   optional: false
 - name: bzip2
@@ -185,6 +162,18 @@ package:
     sha256: ab6e9856c21709b7b517e940ae7028ae0737546122f83c2aa5d692860c3b149e
   category: main
   optional: false
+- name: libgfortran5
+  version: 13.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=13.2.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-13.2.0-ha4646dd_2.conda
+  hash:
+    md5: 78fdab09d9138851dde2b5fe2a11019e
+    sha256: 55ecf5c46c05a98b4822a041d6e1cb196a7b0606126eb96b24131b7d2c8ca561
+  category: main
+  optional: false
 - name: libnsl
   version: 2.0.0
   manager: conda
@@ -195,20 +184,6 @@ package:
   hash:
     md5: 39b1328babf85c7c3a61636d9cd50206
     sha256: 32f4fb94d99946b0dabfbbfd442b25852baf909637f2eed1ffe3baea15d02aad
-  category: main
-  optional: false
-- name: libopenblas
-  version: 0.3.23
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libgfortran-ng: ''
-    libgfortran5: '>=11.3.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.23-pthreads_h80387f5_0.conda
-  hash:
-    md5: 9c5ea51ccb8ffae7d06c645869d24ce6
-    sha256: 00aee12d04979d024c7f9cabccff5f5db2852c934397ec863a4abde3e09d5a79
   category: main
   optional: false
 - name: libuuid
@@ -248,16 +223,16 @@ package:
   category: main
   optional: false
 - name: openssl
-  version: 3.1.2
+  version: 3.1.3
   manager: conda
   platform: linux-64
   dependencies:
     ca-certificates: ''
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.1.2-hd590300_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.1.3-hd590300_0.conda
   hash:
-    md5: e5ac5227582d6c83ccf247288c0eb095
-    sha256: b113fbac327c90cdc29c2fac0f2a2e5cc0d1918b2a5ffa7abd49b695b9b3c6e9
+    md5: 7bb88ce04c8deb9f7d763ae04a1da72f
+    sha256: f4e35f506c7e8ab7dfdc47255b0d5aa8ce0c99028ae0affafd274333042c4f70
   category: main
   optional: false
 - name: xz
@@ -272,16 +247,16 @@ package:
     sha256: 03a6d28ded42af8a347345f82f3eebdd6807a08526d47899a42d62d319609162
   category: main
   optional: false
-- name: libblas
-  version: 3.9.0
+- name: libgfortran-ng
+  version: 13.2.0
   manager: conda
   platform: linux-64
   dependencies:
-    libopenblas: '>=0.3.23,<1.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-17_linux64_openblas.conda
+    libgfortran5: 13.2.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-13.2.0-h69a702a_2.conda
   hash:
-    md5: 57fb44770b1bc832fb2dbefa1bd502de
-    sha256: 5a9dfeb9ede4b7ac136ac8c0b589309f8aba5ce79d14ca64ad8bffb3876eb04b
+    md5: e75a75a6eaf6f318dae2631158c46575
+    sha256: 767d71999e5386210fe2acaf1b67073e7943c2af538efa85c101e3401e94ff62
   category: main
   optional: false
 - name: libsqlite
@@ -323,28 +298,18 @@ package:
     sha256: 032fd769aad9d4cad40ba261ab222675acb7ec951a8832455fce18ef33fa8df0
   category: main
   optional: false
-- name: libcblas
-  version: 3.9.0
+- name: libopenblas
+  version: 0.3.24
   manager: conda
   platform: linux-64
   dependencies:
-    libblas: 3.9.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-17_linux64_openblas.conda
+    libgcc-ng: '>=12'
+    libgfortran-ng: ''
+    libgfortran5: '>=12.3.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.24-pthreads_h413a1c8_0.conda
   hash:
-    md5: 7ef0969b00fe3d6eef56a8151d3afb29
-    sha256: 535bc0a6bc7641090b1bdd00a001bb6c4ac43bce2a11f238bc6676252f53eb3f
-  category: main
-  optional: false
-- name: liblapack
-  version: 3.9.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libblas: 3.9.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-17_linux64_openblas.conda
-  hash:
-    md5: a2103882c46492e26500fcb56c03de8b
-    sha256: 45128394d2f4d4caf949c1b02bff1cace3ef2e33762dbe8f0edec7701a16aaa9
+    md5: 6e4ef6ca28655124dcde9bd500e44c32
+    sha256: c8e080ae4d57506238023e98869928ae93564e6407ef5b0c4d3a337e8c2b7662
   category: main
   optional: false
 - name: python
@@ -374,6 +339,80 @@ package:
     sha256: 920fe89dbc4aaf910e7a37cb4d865eaabe7ff1e5e6c3888d56fe7742ab181448
   category: main
   optional: false
+- name: libblas
+  version: 3.9.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libopenblas: '>=0.3.24,<1.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-18_linux64_openblas.conda
+  hash:
+    md5: bcddbb497582ece559465b9cd11042e7
+    sha256: 92142c12eb42172365c96c865be8f164a2653649b28b23bded0e658f8d5d0815
+  category: main
+  optional: false
+- name: setuptools
+  version: 68.2.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-68.2.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: fc2166155db840c634a1291a5c35a709
+    sha256: 851901b1f8f2049edb36a675f0c3f9a98e1495ef4eb214761b048c6f696a06f7
+  category: main
+  optional: false
+- name: wheel
+  version: 0.41.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.41.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: 1ccd092478b3e0ee10d7a891adbf8a4f
+    sha256: 21bcec5373b04d739ab65252b5532b04a08d229865ebb24b5b94902d6d0a77b0
+  category: main
+  optional: false
+- name: libcblas
+  version: 3.9.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libblas: 3.9.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-18_linux64_openblas.conda
+  hash:
+    md5: 93dd9ab275ad888ed8113953769af78c
+    sha256: b5a3eac5a1e14ad7054a19249afeee6536ab8c9fb6d6ddc26e277f5c3b1acce4
+  category: main
+  optional: false
+- name: liblapack
+  version: 3.9.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libblas: 3.9.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-18_linux64_openblas.conda
+  hash:
+    md5: a1244707531e5b143c420c70573c8ec5
+    sha256: 7b59c9bf8399b34818d36c7bbd30cd447649fe4ff2136d3102bb67da0af67a3a
+  category: main
+  optional: false
+- name: pip
+  version: 23.2.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.7'
+    setuptools: ''
+    wheel: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/pip-23.2.1-pyhd8ed1ab_0.conda
+  hash:
+    md5: e2783aa3f9235225eec92f9081c5b801
+    sha256: 9e401b171856e12f6aa32ae5cc1ae1d3708aa7d705ddf359ee7dd0dffd73c2b5
+  category: main
+  optional: false
 - name: numpy
   version: 1.25.2
   manager: conda
@@ -390,43 +429,5 @@ package:
   hash:
     md5: 71fd6f1734a0fa64d8f852ae7156ec45
     sha256: 2e74d2f11d85e0a796a14b63702c7a963244795c52f92ea98b6f2c0d7620c065
-  category: main
-  optional: false
-- name: setuptools
-  version: 68.1.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-68.1.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 4fe12573bf499ff85a0a364e00cc5c53
-    sha256: dc5a777597e05ceddefc87d2f96389b7ae0afb097e558307af83a453db3e3887
-  category: main
-  optional: false
-- name: wheel
-  version: 0.41.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.41.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 1ccd092478b3e0ee10d7a891adbf8a4f
-    sha256: 21bcec5373b04d739ab65252b5532b04a08d229865ebb24b5b94902d6d0a77b0
-  category: main
-  optional: false
-- name: pip
-  version: 23.2.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7'
-    setuptools: ''
-    wheel: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/pip-23.2.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: e2783aa3f9235225eec92f9081c5b801
-    sha256: 9e401b171856e12f6aa32ae5cc1ae1d3708aa7d705ddf359ee7dd0dffd73c2b5
   category: main
   optional: false

--- a/conda-lock.yml
+++ b/conda-lock.yml
@@ -332,7 +332,6 @@ package:
     tk: '>=8.6.12,<8.7.0a0'
     tzdata: ''
     xz: '>=5.2.6,<6.0a0'
-    pip: ''
   url: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.5-hab00c5b_0_cpython.conda
   hash:
     md5: f0288cb82594b1cbc71111d1cd3c5422
@@ -349,30 +348,6 @@ package:
   hash:
     md5: bcddbb497582ece559465b9cd11042e7
     sha256: 92142c12eb42172365c96c865be8f164a2653649b28b23bded0e658f8d5d0815
-  category: main
-  optional: false
-- name: setuptools
-  version: 68.2.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-68.2.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: fc2166155db840c634a1291a5c35a709
-    sha256: 851901b1f8f2049edb36a675f0c3f9a98e1495ef4eb214761b048c6f696a06f7
-  category: main
-  optional: false
-- name: wheel
-  version: 0.41.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.41.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 1ccd092478b3e0ee10d7a891adbf8a4f
-    sha256: 21bcec5373b04d739ab65252b5532b04a08d229865ebb24b5b94902d6d0a77b0
   category: main
   optional: false
 - name: libcblas
@@ -397,20 +372,6 @@ package:
   hash:
     md5: a1244707531e5b143c420c70573c8ec5
     sha256: 7b59c9bf8399b34818d36c7bbd30cd447649fe4ff2136d3102bb67da0af67a3a
-  category: main
-  optional: false
-- name: pip
-  version: 23.2.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7'
-    setuptools: ''
-    wheel: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/pip-23.2.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: e2783aa3f9235225eec92f9081c5b801
-    sha256: 9e401b171856e12f6aa32ae5cc1ae1d3708aa7d705ddf359ee7dd0dffd73c2b5
   category: main
   optional: false
 - name: numpy


### PR DESCRIPTION
Enable the [`--mamba`](https://conda.github.io/conda-lock/flags/#-mamba) option of conda-lock for faster solves.

TODO:
- [x] Check if `mamba` is installed
- [x] Install mamba into composite GitHub Action
- [x] Use `conda-lock --mamba ...`
- [x] Let mamba solver be configurable with a true/false boolean flag (default is to use mamba)